### PR TITLE
Update package.json to include repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "express-livereload",
   "version": "0.0.24",
   "description": "Adds livereload functionality to express app to make development easier on express app without repetitive ⌘ + S",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mnmly/express-livereload"
+  },
   "dependencies": {
     "livereload": "git://github.com/mnmly/node-livereload.git"
   }


### PR DESCRIPTION
What
Update package.json to include repository field

Why
- Node 10 (npm 6.4.1) appears to require npm packages to define the repository field.